### PR TITLE
Simplify CLI utilities

### DIFF
--- a/data_split.py
+++ b/data_split.py
@@ -1,57 +1,46 @@
-import numpy as np
-import pandas as pd
-from rdkit import Chem
-from rdkit.Chem import AllChem
-from rdkit.ML.Descriptors import MoleculeDescriptors
-from rdkit.Chem import Descriptors, Lipinski, rdMolDescriptors
-import sklearn.metrics as metrics
-from sklearn.preprocessing import StandardScaler
-from sklearn.model_selection import train_test_split
 import argparse
-import pickle
-import joblib
-import os
+import pandas as pd
+
+from sklearn.model_selection import train_test_split
+
 from utils import data_preprocessing
 
-if __name__=="__main__":
-    parser=argparse.ArgumentParser()
-    parser.add_argument('--file_name', type=str, default='smiles.csv', help='Path to the input file')
-    parser.add_argument('--split_mode', choices=['scaffold', 'stratify'], default='stratify', help='Seperate method of dataset for train/test set')
-    parser.add_argument('--test_frac', type=float, default=0.2, help='Test set fraction (default: 0.2)')
-    args  =parser.parse_args()
-    
+def split_dataset(df: pd.DataFrame, mode: str, frac: float):
+    """Split data into train/test sets using the requested mode."""
+    if mode == "stratify":
+        train_data, test_data = train_test_split(
+            df,
+            random_state=42,
+            test_size=frac,
+            stratify=df["bioclass"],
+            shuffle=True,
+        )
+    else:
+        from dgllife.utils import ScaffoldSplitter
+
+        df = df.rename(columns={"SMILES": "smiles"})
+        train_set, _, test_set = ScaffoldSplitter.train_val_test_split(
+            df, frac_train=1 - frac, frac_val=0, frac_test=frac
+        )
+        train_data = df.iloc[train_set.indices]
+        test_data = df.iloc[test_set.indices]
+
+    print(f"Size of train dataset: {len(train_data)}")
+    print(f"Size of test  dataset: {len(test_data)}")
+    return train_data, test_data
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file_name", default="smiles.csv", help="Path to the input file")
+    parser.add_argument("--split_mode", choices=["scaffold", "stratify"], default="stratify", help="Dataset splitting method")
+    parser.add_argument("--test_frac", type=float, default=0.2, help="Test set fraction (default: 0.2)")
+    args = parser.parse_args()
+
     df = pd.read_csv(args.file_name)
-    # preprocess from smiles to features
-    print(f'Start data pre-processing for {args.file_name}')
+    print(f"Start data pre-processing for {args.file_name}")
     df = data_preprocessing(df)
 
-    if args.split_mode == 'stratify' :
-        print('stratified split')
-        from sklearn.model_selection import train_test_split
-        train_data, test_data = train_test_split(
-                                                  df, 
-                                                  random_state=42, 
-                                                  test_size = args.test_frac, 
-                                                  stratify=df['bioclass'], 
-                                                  shuffle = True
-                                                )
-        print(f'Size of train dataset: {len(train_data)} ')
-        print(f'Size of test  dataset: {len(test_data)} ')
-        train_data.to_csv(f'train_{args.file_name}',index=False)
-        test_data.to_csv(f'test_{args.file_name}',index=False)
-    elif args.split_mode =='scaffold' :
-        print('scaffold-based split')
-        from dgllife.utils import ScaffoldSplitter
-        df = df.rename(columns={'SMILES': 'smiles'})
-        train_set, val_set, test_set = ScaffoldSplitter.train_val_test_split(
-                              df,
-                              frac_train=1-args.test_frac,
-                              frac_val=0,
-                              frac_test=args.test_frac,
-                              )
-        train_data = df.iloc[train_set.indices]
-        test_data  = df.iloc[test_set.indices]
-        print(f'Size of train dataset: {len(train_data)} ')
-        print(f'Size of test  dataset: {len(test_data)} ')
-        train_data.to_csv(f'train_{args.file_name}',index=False)
-        test_data.to_csv(f'test_{args.file_name}',index=False)
+    train_data, test_data = split_dataset(df, args.split_mode, args.test_frac)
+    train_data.to_csv(f"train_{args.file_name}", index=False)
+    test_data.to_csv(f"test_{args.file_name}", index=False)

--- a/model.py
+++ b/model.py
@@ -1,25 +1,17 @@
-from sklearn.ensemble import RandomForestClassifier ###1. RandomForest
-from sklearn import svm ###2. SVM
-import xgboost as xgb ###3. XGB
-from sklearn.ensemble import GradientBoostingClassifier ###4.GB
-import time
-import pandas as pd
-import numpy as np
-from numpy import array
-import pickle
-import os
-from os import path
-import sklearn
-from sklearn.metrics import roc_auc_score, make_scorer, recall_score, accuracy_score, matthews_corrcoef, confusion_matrix
-from sklearn.model_selection import StratifiedKFold, cross_validate
-from hpsklearn import HyperoptEstimator, any_preprocessing, any_classifier
-from hpsklearn import random_forest_classifier, gradient_boosting_classifier, svc, xgboost_classification, k_neighbors_classifier
-from sklearn.svm import SVC
-from hyperopt import tpe, hp
 import argparse
-from utils import data_preprocessing
+import pickle
+import time
+
+import numpy as np
+import pandas as pd
+from hyperopt import tpe
+from hpsklearn import HyperoptEstimator, any_classifier, any_preprocessing
+from sklearn.metrics import roc_auc_score, confusion_matrix
+from sklearn.model_selection import StratifiedKFold
 from torch.utils.data import Dataset
 from dgllife.utils import ScaffoldSplitter
+
+from utils import data_preprocessing, load_features
 
 class MoleculeDataset(Dataset):
     def __init__(self, smiles, labels):
@@ -45,7 +37,7 @@ if __name__=="__main__":
 
     args  =parser.parse_args()
     print(args)
-    features = eval(open(f'./features.txt', 'r').read())
+    features = load_features()
     if args.model_name is None:
         args.model_name = args.file_name[:-4]
     print(f'User-defined model name: {args.model_name}')

--- a/utils.py
+++ b/utils.py
@@ -6,13 +6,17 @@ from rdkit.ML.Descriptors import MoleculeDescriptors
 from rdkit.Chem import Descriptors, Lipinski, rdMolDescriptors
 import sklearn.metrics as metrics
 from sklearn.preprocessing import StandardScaler
+# For script usage
 import argparse
-import pickle
 import joblib
-import os
 #from hpsklearn.components import classifier
 
 pd.set_option('display.max_columns', None)
+
+def load_features(path: str = 'features.txt') -> list:
+    """Load feature names from a text file."""
+    with open(path, 'r') as f:
+        return eval(f.read())
 
 def data_preprocessing(tmp_df):
     org_df = len(tmp_df)
@@ -80,17 +84,14 @@ def standard_scaled(all_data):
 
     return pd.concat([results_df, all_data[['SMILES','bioclass']]], axis=1)
 
-if __name__=="__main__":
-    parser=argparse.ArgumentParser()
-    parser.add_argument('--file_name', type=str, default='Papp_final_data')
-    parser.add_argument('--feature_name', type=str, default='Caco2_permeability')
-    args  =parser.parse_args()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file_name", type=str, default="test_example.csv")
+    args = parser.parse_args()
 
-    features = eval(open(f'./features.txt', 'r').read())#CYP1A2_inhibition/
-    print(len(features))
-    tmp_df = pd.read_csv('test_example.csv')
+    features = load_features()
+    print(f"Loaded {len(features)} features")
 
-    # preprocess the smiles
-    scaled_all_data = data_preprocessing(tmp_df)
-    print(scaled_all_data)
-    exit(-1)
+    df = pd.read_csv(args.file_name)
+    scaled = data_preprocessing(df)
+    print(scaled)


### PR DESCRIPTION
## Summary
- refactor prediction and data splitting scripts into clearer functions
- cleanup unused imports in model script and load features through utility
- add `load_features` helper to utils

## Testing
- `python -m py_compile utils.py predict.py data_split.py model.py`
- ⚠️ `pip install numpy pandas scikit-learn hyperopt hpsklearn torch torchvision joblib dgllife==0.3.2 rdkit-pypi` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_687ecb06b8e4832b91f525124b2bc781